### PR TITLE
Small doc fixes

### DIFF
--- a/docs/examples/azcausal.ipynb
+++ b/docs/examples/azcausal.ipynb
@@ -169,11 +169,9 @@
   {
    "cell_type": "markdown",
    "id": "9",
-   "metadata": {
-    "title": "As before, we may now go about estimating the treatment. However, this"
-   },
+   "metadata": {},
    "source": [
-    "time we see that the delta between the estaimted and true effect is much larger than\n",
+    "As before, we may now go about estimating the treatment. However, this time we see that the delta between the estimated and true effect is much larger than\n",
     "before."
    ]
   },

--- a/docs/examples/basic.ipynb
+++ b/docs/examples/basic.ipynb
@@ -54,11 +54,9 @@
   {
    "cell_type": "markdown",
    "id": "3",
-   "metadata": {
-    "title": "Simulating a dataset is as simple as specifying a `Config` object and"
-   },
+   "metadata": {},
    "source": [
-    "then invoking the `simulate` function. Once simulated, we may visualise the data\n",
+    "Simulating a dataset is as simple as specifying a `Config` object and then invoking the `simulate` function. Once simulated, we may visualise the data\n",
     "through the `plot` function."
    ]
   },
@@ -321,7 +319,7 @@
     "variation. In a follow-up notebook, we show how these datasets may be integrated with\n",
     "Amazon's own AZCausal library to compare the effect estimated by a model with the true\n",
     "effect of the underlying data generating process. A link to this notebook is\n",
-    "[here](http://localhost:9998/causal-validation/examples/azcausal/)."
+    "[here](https://amazon-science.github.io/causal-validation/examples/azcausal/)."
    ]
   }
  ],

--- a/docs/examples/placebo_test.ipynb
+++ b/docs/examples/placebo_test.ipynb
@@ -207,22 +207,6 @@
     "datasets = DatasetContainer([data, complex_data], names=[\"Simple\", \"Complex\"])\n",
     "PlaceboTest([model, did_model], datasets).execute().summary()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Checklist

- [N/A] I've formatted the new code by running `hatch run dev:format` before committing.
- [N/A] I've added tests for new code.
- [N/A] I've added docstrings for the new code.

## Description

The example notebooks contained some doc issues, which have been resolved in this PR.

- [Data Synthesis](https://amazon-science.github.io/causal-validation/examples/basic/)
    - Part of some paragraphs was wrongfully assigned as `metadata/title`, as a result it didn't show up in the notebook (e.g., [this paragraph](https://amazon-science.github.io/causal-validation/examples/basic/#:~:text=parameter%20import%20UnitVaryingParameter-,Simulating%20a%20Dataset,-then%20invoking%20the))
    - Contained broken link in last paragraph
- [Placebo Testing](https://amazon-science.github.io/causal-validation/examples/placebo_test/)
    - Contained redundant cells
- [AZCausal Integration](https://amazon-science.github.io/causal-validation/examples/azcausal/)
    - Part of some paragraphs was wrongfully assigned as `metadata/title`, as a result it didn't show up in the notebook (e.g., [this paragraph](https://amazon-science.github.io/causal-validation/examples/azcausal/#:~:text=will%20inflate%20the%20treated%20group%27s%20observations%20in%20the%20post%2Dintervention%20window.))

Issue Number: N/A