### PR TITLE
Pin jQuery version in generated docs pages

### DIFF
--- a/hooks/pin_jquery_version.py
+++ b/hooks/pin_jquery_version.py
@@ -1,0 +1,46 @@
+"""MkDocs hook: pin the jQuery version used by rendered notebook pages.
+
+The ``mknotebooks`` plugin injects a Jupyter-widgets renderer snippet into every
+rendered notebook page. That snippet references an old jQuery release from a CDN.
+This hook normalises any older jQuery reference in the generated HTML to a single
+current, pinned release so the documentation site loads a consistent version.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Minimum jQuery version to keep; anything below is bumped to PINNED_VERSION.
+MIN_VERSION = (3, 5, 0)
+PINNED_VERSION = "3.7.1"
+
+# Matches CDN references such as:
+#   https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js
+#   https://code.jquery.com/jquery-1.12.4.min.js
+_CDNJS_RE = re.compile(r"(ajax/libs/jquery/)(\d+)\.(\d+)\.(\d+)(/jquery)")
+_JQUERY_COM_RE = re.compile(r"(jquery-)(\d+)\.(\d+)\.(\d+)(\.min\.js)")
+
+
+def _below_min(major: int, minor: int, patch: int) -> bool:
+    return (major, minor, patch) < MIN_VERSION
+
+
+def _bump_cdnjs(match: re.Match) -> str:
+    major, minor, patch = (int(match.group(i)) for i in (2, 3, 4))
+    if _below_min(major, minor, patch):
+        return f"{match.group(1)}{PINNED_VERSION}{match.group(5)}"
+    return match.group(0)
+
+
+def _bump_jquery_com(match: re.Match) -> str:
+    major, minor, patch = (int(match.group(i)) for i in (2, 3, 4))
+    if _below_min(major, minor, patch):
+        return f"{match.group(1)}{PINNED_VERSION}{match.group(5)}"
+    return match.group(0)
+
+
+def on_post_page(output: str, page, config) -> str:  # noqa: ANN001, ARG001
+    """Pin older jQuery references in a rendered page's HTML."""
+    patched = _CDNJS_RE.sub(_bump_cdnjs, output)
+    patched = _JQUERY_COM_RE.sub(_bump_jquery_com, patched)
+    return patched

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,12 @@ markdown_extensions:
       pygments_style: vs
       noclasses: true
 
+hooks:
+  # Pins the jQuery version referenced by rendered notebook pages to a single
+  # current release. Kept outside docs/ so it is not published as a static
+  # asset. See hooks/pin_jquery_version.py.
+  - hooks/pin_jquery_version.py
+
 plugins:
   - search
   - mkdocstrings


### PR DESCRIPTION
## Summary
Pins the jQuery version referenced by the rendered notebook pages of the documentation site to a single current release.

## Background
The `mknotebooks` plugin injects a Jupyter-widgets renderer snippet into each rendered notebook page (`basic`, `placebo_test`, `azcausal`). That snippet references an older jQuery release from a CDN. This normalises it to a consistent, current version.

## Change
- Add an mkdocs `on_post_page` hook (`hooks/pin_jquery_version.py`) that rewrites older jQuery references in the generated HTML to a pinned 3.7.1.
- Handles both the cdnjs (`ajax/libs/jquery/x.y.z/jquery.min.js`) and code.jquery.com (`jquery-x.y.z.min.js`) URL forms; leaves current versions and non-jQuery scripts untouched.
- Placed outside `docs/` so the hook source is not published as a static asset.
- Registered via `hooks:` in `mkdocs.yml`; runs on every `mkdocs build`/deploy.

## Testing
Built the docs locally and compared the generated HTML with and without the hook:

| Generated page | Without hook | With hook |
| --- | --- | --- |
| `examples/azcausal/index.html` | jquery/2.0.3 | jquery/3.7.1 |
| `examples/basic/index.html` | jquery/2.0.3 | jquery/3.7.1 |
| `examples/placebo_test/index.html` | jquery/2.0.3 | jquery/3.7.1 |

With the hook, all rendered pages reference jQuery 3.7.1 and no reference below 3.5.0 remains anywhere in the built site. The control build (hook removed) confirms the pinning is what changes the output.